### PR TITLE
style: fix icon position

### DIFF
--- a/components/Sidebar.vue
+++ b/components/Sidebar.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="px-32px w-380px min-h-screen border-l border-gray-200">
-    developer-plus
-    <dark-toggle />
+    <div flex gap-3>
+      developer-plus
+      <dark-toggle />
+    </div>
   </div>
 </template>


### PR DESCRIPTION
修复侧边栏文字和 icon 对齐的问题，也方便后续 github icon 的放置

<img width="443" alt="image" src="https://user-images.githubusercontent.com/8510146/168755026-1c065cb6-afa1-4445-b682-4aca59c0ec4a.png">